### PR TITLE
Implement AJAX lazy loading for account detail tabs

### DIFF
--- a/scan/templates/accounts/detail.html
+++ b/scan/templates/accounts/detail.html
@@ -67,8 +67,24 @@ const template = `
        field.innerHTML = out;
      } catch (_e) {
      }
-   }
- }
+  }
+}
+</script>
+<script>
+  $(function () {
+    $('a[data-toggle="tab"]').on('shown.bs.tab', function (e) {
+      var target = $($(e.target).attr('href'));
+      var container = target.find('.lazy-tab');
+      if (container.length && container.is(':empty')) {
+        container.html(
+          '<div class="text-center my-4"><div class="spinner-border" role="status"><span class="sr-only">Loading...</span></div></div>'
+        );
+        $.get(container.data('url'), function (data) {
+          container.html(data);
+        });
+      }
+    });
+  });
 </script>
 {% endblock %}
 
@@ -238,7 +254,7 @@ const template = `
                 <p class=style="margin-top: 10px">
                   <div class="float-left small p-1">Account holds {{ assets_cnt|intcomma }} tokens</div>
                 </p>
-                {% include "accounts/assets.html" with filtered_account=address.id %}
+                <div class="lazy-tab" data-url="{% url 'address-detail' address.id %}?tab=assets"></div>
               {% else %}
                 <p class="small p-1" style="margin-top: 10px">No tokens found</p>
               {% endif %}
@@ -252,7 +268,7 @@ const template = `
                     <a href="{% url 'asset-trades' %}?a={{ address.id }}">View all trades</a>
                   </div>
                 </p>
-                {% include "assets/trades_list.html" %}
+                <div class="lazy-tab" data-url="{% url 'address-detail' address.id %}?tab=trades"></div>
                 <div class="float-right  small p-1">
                   <a href="{% url 'asset-trades' %}?a={{ address.id }}">View all trades</a>
                 </div>
@@ -269,7 +285,7 @@ const template = `
                     <a href="{% url 'asset-transfers' %}?a={{ address.id }}">View all transfers</a>
                   </div>
                 </p>
-                {% include "assets/transfers_list.html" with filtered_account=address.id %}
+                <div class="lazy-tab" data-url="{% url 'address-detail' address.id %}?tab=transfers"></div>
                 <div class="float-right  small p-1">
                   <a href="{% url 'asset-transfers' %}?a={{ address.id }}">View all transfers</a>
                 </div>
@@ -289,7 +305,7 @@ const template = `
                     <a href="{% url 'ats' %}?a={{ address.id }}">View all contracts</a>
                   </div>
                 </p>
-                {% include "accounts/ats.html" %}
+                <div class="lazy-tab" data-url="{% url 'address-detail' address.id %}?tab=ats"></div>
                 <div class="float-right  small p-1">
                   <a href="{% url 'ats' %}?a={{ address.id }}">View all contracts</a>
                 </div>
@@ -307,7 +323,7 @@ const template = `
                     <a href="{% url 'blocks' %}?m={{ address.id }}">View all blocks</a>
                   </div>
                 </p>
-                {% include "accounts/mined_blocks.html" %}
+                <div class="lazy-tab" data-url="{% url 'address-detail' address.id %}?tab=mined_blocks"></div>
                 <div class="float-right  small p-1">
                   <a href="{% url 'blocks' %}?m={{ address.id }}">View all blocks</a>
                 </div>
@@ -323,7 +339,7 @@ const template = `
                     <a href="{% url 'cbs' %}?a={{ address.id }}">View all Cashbacks</a>
                   </div>
                 </p>
-                {% include "accounts/cashback.html" %}
+                <div class="lazy-tab" data-url="{% url 'address-detail' address.id %}?tab=cashback"></div>
                 <div class="float-right  small p-1">
                   <a href="{% url 'cbs' %}?a={{ address.id }}">View all Cashbacks</a>
                 </div>
@@ -339,7 +355,7 @@ const template = `
                     <a href="{% url 'alias' %}?a={{ address.id }}">View all Aliases</a>
                   </div>
                 </p>
-                {% include "accounts/alias.html" %}
+                <div class="lazy-tab" data-url="{% url 'address-detail' address.id %}?tab=alias"></div>
               {% else %}
                 <p class="small p-1" style="margin-top: 10px">No aliases found</p>
               {% endif %}
@@ -355,7 +371,7 @@ const template = `
                     <a href="{% url 'subscription' %}?a={{ address.id }}">View all Auto-Payments</a>
                   </div>
                 </p>
-                {% include "accounts/subscription.html" %}
+                <div class="lazy-tab" data-url="{% url 'address-detail' address.id %}?tab=subscription"></div>
               {% else %}
                 <p class="small p-1" style="margin-top: 10px">No auto-payments found</p>
               {% endif %}

--- a/scan/views/accounts.py
+++ b/scan/views/accounts.py
@@ -3,6 +3,7 @@ from django.views.generic import ListView
 from django.views.decorators.cache import cache_page
 from django.utils.decorators import method_decorator
 from django.core.cache import cache
+from django.shortcuts import render
 
 from java_wallet.models import (
     Account,
@@ -244,3 +245,21 @@ class AddressDetailView(IntSlugDetailView):
         )
 
         return context
+
+    def render_to_response(self, context, **response_kwargs):
+        tab = self.request.GET.get("tab")
+        templates = {
+            "assets": "accounts/assets.html",
+            "trades": "assets/trades_list.html",
+            "transfers": "assets/transfers_list.html",
+            "ats": "accounts/ats.html",
+            "mined_blocks": "accounts/mined_blocks.html",
+            "cashback": "accounts/cashback.html",
+            "alias": "accounts/alias.html",
+            "subscription": "accounts/subscription.html",
+        }
+
+        if tab in templates:
+            return render(self.request, templates[tab], context)
+
+        return super().render_to_response(context, **response_kwargs)


### PR DESCRIPTION
## Summary
- enable dynamic tab loading in `AddressDetailView`
- fetch tab content on demand in account detail template
- display spinner while tab loads

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_68546e3177c0832abfb68985cea88828